### PR TITLE
Include setuptools instead of distutils.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 from __version__ import __version__
 


### PR DESCRIPTION
Distutils does not support the develop command, that's a part of
setuptools. I changed the default setup command from distutils to
setuptools so that the develop command could be used, but I included a
fallback of distutils if setuptools is not available. Closes #5.