### PR TITLE
Use GNU parallel to speed up circleci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,11 +24,7 @@ jobs:
             echo 'eval "$(pyenv init -)"' >>~/.bash_profile
             echo 'eval "$(pyenv virtualenv-init -)"' >>~/.bash_profile
             source ~/.bash_profile
-            pyenv install 2.7.13
-            pyenv install 3.3.6
-            pyenv install 3.4.6
-            pyenv install 3.5.3
-            pyenv install 3.6.2
+            parallel -j 5 pyenv install ::: 2.7.13 3.3.6 3.4.6 3.5.3 3.6.2
             pyenv local 2.7.13 3.3.6 3.4.6 3.5.3 3.6.2
       - save_cache:
           paths:


### PR DESCRIPTION
Looking at the circleCI site, I can see that the bulk of the time for
the build is spent installing all of the different python versions
under pyenv. We can use the GNU parallel command to easily run all of
these installs at the same time. I have verified that the parallel
command is available in the circleci python image. Should help with #4.